### PR TITLE
fix(lint): fix remaining RuboCop offenses in CI

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -48,6 +48,10 @@ Metrics/ParameterLists:
 Rails:
   Enabled: true
 
+Rails/ThreeStateBooleanColumn:
+  Exclude:
+    - "db/schema.rb"
+
 Rails/HasAndBelongsToMany:
   Enabled: true
 
@@ -104,6 +108,10 @@ Naming/MethodName:
 
 Naming/VariableName:
   EnforcedStyle: snake_case
+
+Naming/VariableNumber:
+  Exclude:
+    - "lib/tasks/**/*"  # Rake task names with years (seed_2025) are legitimate
 
 Naming/AccessorMethodName:
   Enabled: true
@@ -164,5 +172,6 @@ Metrics/BlockLength:
     - "spec/**/*"
     - "config/routes.rb"
     - "db/seeds.rb"
+    - "db/schema.rb"
     - "lib/tasks/**/*"
   Max: 25


### PR DESCRIPTION
- Exclude lib/tasks from Naming/VariableNumber (rake task names with years like seed_2025 are legitimate)
- Exclude db/schema.rb from Rails/ThreeStateBooleanColumn (generated)
- Exclude db/schema.rb from Metrics/BlockLength (generated)

rubocop --format github: 0 errors

## Description

<!-- Quoi et pourquoi ? -->

## Type de changement

- [ ] `feat` — nouvelle feature
- [ ] `fix` — correction de bug
- [ ] `chore` — maintenance (deps, config)
- [ ] `refactor` — refacto sans changement fonctionnel
- [ ] `test` — ajout/modif tests
- [ ] `docs` — documentation

## Checklist

- [ ] Tests RSpec passent (`bundle exec rspec`)
- [ ] RuboCop OK (`bundle exec rubocop`)
- [ ] Migrations incluses si nouveau modèle
- [ ] Pas de `binding.pry` ou `puts` oubliés
- [ ] Logique métier dans Service/Concern (pas dans controller)

## Screenshots (si UI)

<!-- Ajoute des screenshots si changement visuel -->
