### PR TITLE
fix: remove internal draft header from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,3 @@
-# README F1 Analytics — Proposition Colette ✍️
-_Version finale — prête à merger_
-
----
-
 # F1 Analytics 🏎️
 
 > Application Rails de suivi de la saison F1 2026 avec métriques custom.  


### PR DESCRIPTION
Supprime le header interne de Colette (`README F1 Analytics — Proposition Colette ✍️ / Version finale — prête à merger`) qui ne devait pas être visible publiquement.