### PR TITLE
ci: add .env.example

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,31 @@
+# .env.example — Variables d'environnement
+# Copier ce fichier en .env et remplir les valeurs
+# cp .env.example .env
+
+# ─────────────────────────────────────────────
+# Rails
+# ─────────────────────────────────────────────
+
+# Environnement (development | test | production)
+RAILS_ENV=development
+
+# Nombre de threads Puma (optionnel, défaut: 5)
+RAILS_MAX_THREADS=5
+
+# Clé maître Rails (production uniquement)
+# Générer avec: bin/rails credentials:edit
+# RAILS_MASTER_KEY=
+
+# ─────────────────────────────────────────────
+# Base de données (SQLite — aucune config requise en dev/test)
+# ─────────────────────────────────────────────
+
+# En production, spécifier le chemin vers un volume persistant
+# DATABASE_PATH=path/to/persistent/storage/production.sqlite3
+
+# ─────────────────────────────────────────────
+# API externe
+# ─────────────────────────────────────────────
+
+# OpenF1 API — publique, aucune clé requise
+# Doc: https://openf1.org

--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,7 @@
 # Ignore all environment files (except templates).
 /.env*
 !/.env*.erb
+!/.env.example
 
 # Ignore all logfiles and tempfiles.
 /log/*


### PR DESCRIPTION
Ferme #51

- Ajoute `.env.example` avec toutes les variables documentées
- Met à jour `.gitignore` pour que `.env.example` soit commité
- OpenF1 = API publique, aucune clé requise
- Variables Rails standard : `RAILS_ENV`, `RAILS_MAX_THREADS`, `RAILS_MASTER_KEY` (prod only)