### PR TITLE
feat: Chart.js Stimulus controllers + responsive mobile menu (Issues #45 #46)

### DIFF
--- a/app/javascript/controllers/chart_helpers.js
+++ b/app/javascript/controllers/chart_helpers.js
@@ -1,0 +1,59 @@
+// chart_helpers.js — shared utilities for F1 chart controllers
+
+/**
+ * Get the CSS variable value for a team's color.
+ * @param {string} teamKey - e.g. "redbull", "ferrari", "mclaren"
+ * @returns {string} hex color string
+ */
+export function getTeamColor(teamKey) {
+  return getComputedStyle(document.documentElement)
+    .getPropertyValue(`--f1-team-${teamKey}`)
+    .trim()
+}
+
+/**
+ * Format a race name to a short 3-letter code.
+ * Prefers known abbreviations, falls back to first 3 chars.
+ * @param {string} raceName
+ * @returns {string}
+ */
+export function formatRaceName(raceName) {
+  const known = {
+    "Australian Grand Prix": "AUS",
+    "Chinese Grand Prix": "CHN",
+    "Japanese Grand Prix": "JPN",
+    "Bahrain Grand Prix": "BHR",
+    "Saudi Arabian Grand Prix": "SAU",
+    "Miami Grand Prix": "MIA",
+    "Canadian Grand Prix": "CAN",
+    "Monaco Grand Prix": "MON",
+    "Spanish Grand Prix": "ESP",
+    "Austrian Grand Prix": "AUT",
+    "British Grand Prix": "GBR",
+    "Belgian Grand Prix": "BEL",
+    "Hungarian Grand Prix": "HUN",
+    "Dutch Grand Prix": "NED",
+    "Italian Grand Prix": "ITA",
+    "Madrid Grand Prix": "MAD",
+    "Azerbaijan Grand Prix": "AZE",
+    "Singapore Grand Prix": "SGP",
+    "United States Grand Prix": "USA",
+    "Mexico City Grand Prix": "MEX",
+    "São Paulo Grand Prix": "BRA",
+    "Las Vegas Grand Prix": "LAS",
+    "Qatar Grand Prix": "QAT",
+    "Abu Dhabi Grand Prix": "ABU",
+  }
+  return known[raceName] || raceName.slice(0, 3).toUpperCase()
+}
+
+/**
+ * Shared Chart.js global options applied to all F1 charts.
+ * Call once per page (chart_defaults_controller handles it for the whole app).
+ */
+export const F1_CHART_DEFAULTS = {
+  color: "#A0A0A0",
+  borderColor: "#2E2E2E",
+  backgroundColor: "#1A1A1A",
+  font: { family: "'Inter', system-ui, sans-serif" },
+}

--- a/app/javascript/controllers/mobile_menu_controller.js
+++ b/app/javascript/controllers/mobile_menu_controller.js
@@ -1,0 +1,39 @@
+// mobile_menu_controller.js — Issue #46 — Bender 🤖
+// Toggles the mobile nav menu and updates aria-expanded
+
+import { Controller } from "@hotwired/stimulus"
+
+export default class extends Controller {
+  static targets = ["menu"]
+
+  toggle(event) {
+    const button = event.currentTarget
+    const isOpen = !this.menuTarget.classList.contains("hidden")
+
+    if (isOpen) {
+      this.menuTarget.classList.add("hidden")
+      button.setAttribute("aria-expanded", "false")
+    } else {
+      this.menuTarget.classList.remove("hidden")
+      button.setAttribute("aria-expanded", "true")
+    }
+  }
+
+  // Close menu when clicking outside
+  closeOnOutsideClick(event) {
+    if (!this.element.contains(event.target)) {
+      this.menuTarget.classList.add("hidden")
+      const button = this.element.querySelector("[aria-expanded]")
+      if (button) button.setAttribute("aria-expanded", "false")
+    }
+  }
+
+  connect() {
+    this._outsideHandler = this.closeOnOutsideClick.bind(this)
+    document.addEventListener("click", this._outsideHandler)
+  }
+
+  disconnect() {
+    document.removeEventListener("click", this._outsideHandler)
+  }
+}

--- a/app/javascript/controllers/points_evolution_chart_controller.js
+++ b/app/javascript/controllers/points_evolution_chart_controller.js
@@ -1,0 +1,131 @@
+// points_evolution_chart_controller.js — Issue #45 — Bender 🤖
+// Line chart: cumulative points evolution for a driver + optional teammate
+
+import { Controller } from "@hotwired/stimulus"
+import Chart from "chart.js/auto"
+import { getTeamColor, formatRaceName } from "./chart_helpers"
+
+export default class extends Controller {
+  static targets = ["canvas"]
+  static values = {
+    // [{race_name: "Australian Grand Prix", points: 25, cumulative: 25}, ...]
+    results: Array,
+    // [{race_name: "...", points: ..., cumulative: ...}, ...] — empty array if no teammate
+    teammate: Array,
+    teamKey: String,     // e.g. "redbull"
+    driverName: String,  // last name for legend
+    teammateName: String,
+  }
+
+  connect() {
+    this.chart = new Chart(this.canvasTarget, this.chartConfig())
+  }
+
+  disconnect() {
+    this.chart?.destroy()
+  }
+
+  chartConfig() {
+    const results = this.resultsValue || []
+    const teammate = this.teammateValue || []
+    const hasTeammate = teammate.length > 0
+    const teamColor = getTeamColor(this.teamKeyValue)
+    const isMobile = window.matchMedia("(max-width: 639px)").matches
+
+    const labels = results.map(r => formatRaceName(r.race_name))
+
+    const datasets = [
+      {
+        label: this.driverNameValue || "Driver",
+        data: results.map(r => r.cumulative),
+        borderColor: teamColor,
+        backgroundColor: teamColor + "1A", // 10% alpha fill
+        fill: true,
+        tension: 0.3,
+        pointRadius: 4,
+        pointHoverRadius: 7,
+        pointBackgroundColor: teamColor,
+        borderWidth: 2,
+      },
+    ]
+
+    if (hasTeammate) {
+      datasets.push({
+        label: this.teammateNameValue || "Teammate",
+        data: teammate.map(r => r.cumulative),
+        borderColor: "#606060",
+        backgroundColor: "transparent",
+        fill: false,
+        tension: 0.3,
+        pointRadius: 3,
+        pointHoverRadius: 5,
+        borderDash: [4, 4],
+        borderWidth: 1.5,
+      })
+    }
+
+    return {
+      type: "line",
+      data: { labels, datasets },
+      options: {
+        responsive: true,
+        maintainAspectRatio: false,
+        animation: { duration: 500, easing: "easeOutCubic" },
+
+        interaction: {
+          mode: "index",
+          intersect: false,
+        },
+
+        plugins: {
+          legend: {
+            display: hasTeammate,
+            position: "top",
+            align: "end",
+            labels: {
+              color: "#A0A0A0",
+              font: { family: "'Inter', sans-serif", size: 11 },
+              boxWidth: 12,
+              padding: 16,
+              usePointStyle: true,
+            },
+          },
+          tooltip: {
+            backgroundColor: "#242424",
+            titleColor: "#F5F5F5",
+            bodyColor: "#A0A0A0",
+            borderColor: "#2E2E2E",
+            borderWidth: 1,
+            callbacks: {
+              title: (items) => items[0].label,
+              label: (item) => `${item.dataset.label}: ${item.raw} pts`,
+            },
+          },
+        },
+
+        scales: {
+          x: {
+            grid: { color: "#1F1F1F" },
+            ticks: {
+              color: "#606060",
+              font: { family: "'JetBrains Mono', monospace", size: 10 },
+              maxRotation: 45,
+              maxTicksLimit: isMobile ? 8 : 24,
+            },
+            border: { color: "#2E2E2E" },
+          },
+          y: {
+            grid: { color: "#1F1F1F" },
+            ticks: {
+              color: "#606060",
+              font: { family: "'JetBrains Mono', monospace", size: 11 },
+              callback: (val) => `${val} pts`,
+            },
+            border: { color: "#2E2E2E" },
+            beginAtZero: true,
+          },
+        },
+      },
+    }
+  }
+}

--- a/app/javascript/controllers/standings_chart_controller.js
+++ b/app/javascript/controllers/standings_chart_controller.js
@@ -1,0 +1,107 @@
+// standings_chart_controller.js — Issue #45 — Bender 🤖
+// Horizontal bar chart: Driver Championship Standings
+
+import { Controller } from "@hotwired/stimulus"
+import Chart from "chart.js/auto"
+import { getTeamColor, formatRaceName } from "./chart_helpers"
+
+export default class extends Controller {
+  static targets = ["canvas"]
+  static values = {
+    drivers: Array,   // [{id, last_name, team_key, team_name, total_points}]
+    limit: { type: Number, default: 22 },
+  }
+
+  connect() {
+    this.chart = new Chart(this.canvasTarget, this.chartConfig())
+    this.updateContainerHeight()
+  }
+
+  disconnect() {
+    this.chart?.destroy()
+  }
+
+  // Reduce to top 10 on small screens, show all on desktop
+  updateContainerHeight() {
+    const isMobile = window.matchMedia("(max-width: 639px)").matches
+    const container = this.canvasTarget.parentElement
+    if (isMobile) {
+      container.style.height = "320px"
+      if (this.chart) {
+        this.chart.data.labels = this.visibleDrivers(10).map(d => d.last_name)
+        this.chart.data.datasets[0].data = this.visibleDrivers(10).map(d => d.total_points)
+        this.chart.data.datasets[0].backgroundColor = this.visibleDrivers(10).map(d => getTeamColor(d.team_key))
+        this.chart.data.datasets[0].borderColor = this.visibleDrivers(10).map(d => getTeamColor(d.team_key))
+        this.chart.update()
+      }
+    }
+  }
+
+  visibleDrivers(n = null) {
+    const limit = n || this.limitValue
+    return (this.driversValue || []).slice(0, limit)
+  }
+
+  chartConfig() {
+    const drivers = this.visibleDrivers()
+    const colors = drivers.map(d => getTeamColor(d.team_key))
+
+    return {
+      type: "bar",
+      data: {
+        labels: drivers.map(d => d.last_name),
+        datasets: [{
+          data: drivers.map(d => d.total_points),
+          backgroundColor: colors.map(c => c + "D9"), // ~85% opacity
+          borderColor: colors,
+          borderWidth: 1,
+          borderRadius: 4,
+        }],
+      },
+      options: {
+        indexAxis: "y",
+        responsive: true,
+        maintainAspectRatio: false,
+        animation: { duration: 400, easing: "easeOutQuart" },
+
+        plugins: {
+          legend: { display: false },
+          tooltip: {
+            backgroundColor: "#242424",
+            titleColor: "#F5F5F5",
+            bodyColor: "#A0A0A0",
+            borderColor: "#2E2E2E",
+            borderWidth: 1,
+            callbacks: {
+              title: (items) => items[0].label,
+              label: (item) => `${item.raw} pts`,
+              afterLabel: (item) => {
+                const driver = drivers[item.dataIndex]
+                return `${driver.team_name} · P${item.dataIndex + 1}`
+              },
+            },
+          },
+        },
+
+        scales: {
+          x: {
+            grid: { color: "#1F1F1F" },
+            ticks: {
+              color: "#606060",
+              font: { family: "'JetBrains Mono', monospace", size: 11 },
+            },
+            border: { color: "#2E2E2E" },
+          },
+          y: {
+            grid: { display: false },
+            ticks: {
+              color: "#F5F5F5",
+              font: { family: "'Inter', sans-serif", size: 12 },
+            },
+            border: { color: "#2E2E2E" },
+          },
+        },
+      },
+    }
+  }
+}

--- a/app/javascript/controllers/team_performance_chart_controller.js
+++ b/app/javascript/controllers/team_performance_chart_controller.js
@@ -1,0 +1,121 @@
+// team_performance_chart_controller.js — Issue #45 — Bender 🤖
+// Grouped bar chart: per-race points contribution per driver in a team
+
+import { Controller } from "@hotwired/stimulus"
+import Chart from "chart.js/auto"
+import { getTeamColor, formatRaceName } from "./chart_helpers"
+
+export default class extends Controller {
+  static targets = ["canvas"]
+  static values = {
+    // {
+    //   team_key: "redbull",
+    //   driver1: { name: "Verstappen", results: [{race_name: "...", points: 25}, ...] },
+    //   driver2: { name: "Hadjar",     results: [{race_name: "...", points: 12}, ...] }
+    // }
+    results: Object,
+  }
+
+  connect() {
+    this.chart = new Chart(this.canvasTarget, this.chartConfig())
+  }
+
+  disconnect() {
+    this.chart?.destroy()
+  }
+
+  chartConfig() {
+    const data = this.resultsValue || {}
+    const teamColor = getTeamColor(data.team_key || "redbull")
+    const driver1 = data.driver1 || { name: "Driver 1", results: [] }
+    const driver2 = data.driver2 || { name: "Driver 2", results: [] }
+    const isMobile = window.matchMedia("(max-width: 639px)").matches
+
+    // Build aligned labels from driver1 results (both drivers share the same races)
+    const labels = driver1.results.map(r => formatRaceName(r.race_name))
+
+    return {
+      type: "bar",
+      data: {
+        labels,
+        datasets: [
+          {
+            label: driver1.name,
+            data: driver1.results.map(r => r.points),
+            backgroundColor: teamColor,
+            borderColor: teamColor,
+            borderWidth: 1,
+            borderRadius: 3,
+          },
+          {
+            label: driver2.name,
+            data: driver2.results.map(r => r.points),
+            backgroundColor: teamColor + "80", // 50% alpha
+            borderColor: teamColor,
+            borderWidth: 1,
+            borderRadius: 3,
+          },
+        ],
+      },
+      options: {
+        responsive: true,
+        maintainAspectRatio: false,
+        animation: { duration: 400, easing: "easeOutQuart" },
+
+        plugins: {
+          legend: {
+            display: true,
+            position: "top",
+            align: "end",
+            labels: {
+              color: "#A0A0A0",
+              font: { family: "'Inter', sans-serif", size: 11 },
+              boxWidth: 12,
+              usePointStyle: true,
+            },
+          },
+          tooltip: {
+            mode: "index",
+            intersect: false,
+            backgroundColor: "#242424",
+            titleColor: "#F5F5F5",
+            bodyColor: "#A0A0A0",
+            borderColor: "#2E2E2E",
+            borderWidth: 1,
+            callbacks: {
+              title: (items) => items[0].label,
+              label: (item) => `${item.dataset.label}: ${item.raw} pts`,
+              footer: (items) => {
+                const total = items.reduce((sum, i) => sum + (i.raw || 0), 0)
+                return `Team total: ${total} pts`
+              },
+            },
+          },
+        },
+
+        scales: {
+          x: {
+            grid: { display: false },
+            ticks: {
+              color: "#606060",
+              font: { family: "'JetBrains Mono', monospace", size: 10 },
+              maxRotation: 45,
+              maxTicksLimit: isMobile ? 6 : 24,
+            },
+            border: { color: "#2E2E2E" },
+          },
+          y: {
+            grid: { color: "#1F1F1F" },
+            ticks: {
+              color: "#606060",
+              font: { family: "'JetBrains Mono', monospace", size: 11 },
+              stepSize: 5,
+            },
+            border: { color: "#2E2E2E" },
+            beginAtZero: true,
+          },
+        },
+      },
+    }
+  }
+}


### PR DESCRIPTION
## Charts (#45)

- `chart_helpers.js` — helpers couleurs équipes, formatage noms
- `standings_chart_controller.js` — Chart A: classement pilotes (horizontal bar)
- `points_evolution_chart_controller.js` — Chart B: évolution points (line chart)
- `team_performance_chart_controller.js` — Chart C: perf équipes (grouped bar, prêt pour #34)
- `dashboard_controller.rb` — `@drivers_chart_data` + `@cumulative_points` + `build_cumulative_points`

## Responsive (#46)

- `mobile_menu_controller.js` — burger nav toggle, aria-expanded, close on outside click

## Accessibilité
- `aria-label` + `role="img"` + fallback texte sur chaque canvas
- Couleurs non porteuses d'info seule (tooltip + légende)

⚠️ Dépend de `fix/active-drivers-count` (déjà mergé dans cette branche)

Closes #45
Closes #46

## Checklist
- [ ] `bundle exec rspec`
- [ ] `bundle exec rubocop`
- [ ] `bundle exec brakeman -q` (vérifier `.to_json` inline)