### PR TITLE
ci: auto-deploy to Fly.io on push to main

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,21 @@
+name: Deploy to Fly.io
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  deploy:
+    name: Deploy
+    runs-on: ubuntu-latest
+    concurrency: deploy-group
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: superfly/flyctl-actions/setup-flyctl@master
+
+      - run: flyctl deploy --remote-only
+        env:
+          FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN }}


### PR DESCRIPTION
Adds deploy.yml — chaque push sur main declenche un fly deploy automatique.

Necessite: ajouter FLY_API_TOKEN dans GitHub Secrets (Settings > Secrets > Actions).