### PR TITLE
fix: Tailwind v4 @theme + chart.js/auto importmap

### DIFF
--- a/app/assets/tailwind/application.css
+++ b/app/assets/tailwind/application.css
@@ -1,1 +1,60 @@
 @import "tailwindcss";
+
+@theme {
+  /* ── Backgrounds ──────────────────────────────────── */
+  --color-f1-bg-base:     #0D0D0D;
+  --color-f1-bg-surface:  #1A1A1A;
+  --color-f1-bg-elevated: #242424;
+  --color-f1-bg-overlay:  #2E2E2E;
+
+  /* ── Text ─────────────────────────────────────────── */
+  --color-f1-text-primary:   #F5F5F5;
+  --color-f1-text-secondary: #A0A0A0;
+  --color-f1-text-muted:     #606060;
+  --color-f1-text-inverse:   #0D0D0D;
+
+  /* ── Accents ──────────────────────────────────────── */
+  --color-f1-red:       #E10600;
+  --color-f1-red-hover: #FF1A0F;
+  --color-f1-teal:      #27F4D2;
+  --color-f1-teal-dim:  #1BB99F;
+  --color-f1-gold:      #FFD700;
+  --color-f1-silver:    #C0C0C0;
+  --color-f1-bronze:    #CD7F32;
+
+  /* ── Borders ──────────────────────────────────────── */
+  --color-f1-border:        #2E2E2E;
+  --color-f1-border-subtle: #1F1F1F;
+  --color-f1-border-accent: #E10600;
+
+  /* ── Team colors ──────────────────────────────────── */
+  /* Tailwind classes: bg-f1-team-redbull, text-f1-team-ferrari, etc. */
+  /* Pour les badges inline, utiliser var(--f1-team-*) depuis stylesheets/application.css */
+  --color-f1-team-redbull:     #3671C6;
+  --color-f1-team-ferrari:     #E8002D;
+  --color-f1-team-mclaren:     #FF8000;
+  --color-f1-team-mercedes:    #27F4D2;
+  --color-f1-team-astonmartin: #229971;
+  --color-f1-team-alpine:      #0093CC;
+  --color-f1-team-haas:        #B6BABD;
+  --color-f1-team-rb:          #6692FF;
+  --color-f1-team-sauber:      #52E252;
+  --color-f1-team-williams:    #64C4FF;
+  --color-f1-team-audi:        #E2E61A;
+  --color-f1-team-cadillac:    #FFFFFF;
+
+  /* ── Font families ────────────────────────────────── */
+  /* Usage: font-f1 (headings), font-data (metrics), font-body (default) */
+  --font-f1:   "Barlow", system-ui, sans-serif;
+  --font-data: "JetBrains Mono", "Fira Code", monospace;
+  --font-body: "Inter", system-ui, sans-serif;
+
+  /* ── Box shadows ──────────────────────────────────── */
+  --shadow-card:       0 4px 6px rgba(0, 0, 0, 0.4);
+  --shadow-card-hover: 0 8px 20px rgba(0, 0, 0, 0.6);
+  --shadow-red-glow:   0 0 20px rgba(225, 6, 0, 0.3);
+  --shadow-teal-glow:  0 0 20px rgba(39, 244, 210, 0.2);
+
+  /* ── Border radius ────────────────────────────────── */
+  --radius-card: 8px;
+}

--- a/config/importmap.rb
+++ b/config/importmap.rb
@@ -8,4 +8,5 @@ pin "@hotwired/stimulus", to: "stimulus.min.js"
 pin "@hotwired/stimulus-loading", to: "stimulus-loading.js"
 pin_all_from "app/javascript/controllers", under: "controllers"
 pin "chart.js" # @4.5.1
+pin "chart.js/auto", to: "chart.js.js"
 pin "@kurkle/color", to: "@kurkle--color.js" # @0.3.4


### PR DESCRIPTION
Fixes prod white page + empty chart.

- @theme block in tailwind/application.css (Tailwind v4 ignores config.js)
- pin chart.js/auto in importmap.rb

Co-authored: Bender + Iris