### PR TITLE
fix: replace chart.js/auto with explicit Chart.register

### DIFF
--- a/app/javascript/controllers/chart_defaults_controller.js
+++ b/app/javascript/controllers/chart_defaults_controller.js
@@ -4,7 +4,9 @@
 // Doit être chargé avant tout chart — le body est le nœud racine idéal.
 
 import { Controller } from "@hotwired/stimulus"
-import Chart from "chart.js/auto"
+import { Chart, registerables } from "chart.js"
+
+Chart.register(...registerables)
 
 export default class extends Controller {
   connect() {

--- a/app/javascript/controllers/points_evolution_chart_controller.js
+++ b/app/javascript/controllers/points_evolution_chart_controller.js
@@ -2,8 +2,10 @@
 // Line chart: cumulative points evolution for a driver + optional teammate
 
 import { Controller } from "@hotwired/stimulus"
-import Chart from "chart.js/auto"
+import { Chart, registerables } from "chart.js"
 import { getTeamColor, formatRaceName } from "./chart_helpers"
+
+Chart.register(...registerables)
 
 export default class extends Controller {
   static targets = ["canvas"]

--- a/app/javascript/controllers/standings_chart_controller.js
+++ b/app/javascript/controllers/standings_chart_controller.js
@@ -2,8 +2,10 @@
 // Horizontal bar chart: Driver Championship Standings
 
 import { Controller } from "@hotwired/stimulus"
-import Chart from "chart.js/auto"
+import { Chart, registerables } from "chart.js"
 import { getTeamColor, formatRaceName } from "./chart_helpers"
+
+Chart.register(...registerables)
 
 export default class extends Controller {
   static targets = ["canvas"]

--- a/app/javascript/controllers/team_performance_chart_controller.js
+++ b/app/javascript/controllers/team_performance_chart_controller.js
@@ -2,8 +2,10 @@
 // Grouped bar chart: per-race points contribution per driver in a team
 
 import { Controller } from "@hotwired/stimulus"
-import Chart from "chart.js/auto"
+import { Chart, registerables } from "chart.js"
 import { getTeamColor, formatRaceName } from "./chart_helpers"
+
+Chart.register(...registerables)
 
 export default class extends Controller {
   static targets = ["canvas"]

--- a/config/importmap.rb
+++ b/config/importmap.rb
@@ -8,5 +8,4 @@ pin "@hotwired/stimulus", to: "stimulus.min.js"
 pin "@hotwired/stimulus-loading", to: "stimulus-loading.js"
 pin_all_from "app/javascript/controllers", under: "controllers"
 pin "chart.js" # @4.5.1
-pin "chart.js/auto", to: "chart.js.js"
 pin "@kurkle/color", to: "@kurkle--color.js" # @0.3.4


### PR DESCRIPTION
Fixes the empty Championship Chart in production.

`import Chart from 'chart.js/auto'` was resolving to `undefined` (the vendor bundle has no default auto-export). Replaced with named import + `Chart.register(...registerables)` in all 4 controllers.